### PR TITLE
upgrade aws provider version to ~>6.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>5.0"
+      version = "~>6.0"
     }
   }
 }

--- a/server.tf
+++ b/server.tf
@@ -34,7 +34,7 @@ locals {
 
 resource "aws_instance" "atlantis" {
   region = var.region
-  count = var.spot_instance ? 0 : 1
+  count  = var.spot_instance ? 0 : 1
 
   ami                  = var.ami_id
   instance_type        = var.instance_type
@@ -61,7 +61,7 @@ resource "aws_instance" "atlantis" {
 
 resource "aws_spot_instance_request" "atlantis" {
   region = var.region
-  count = var.spot_instance ? 1 : 0
+  count  = var.spot_instance ? 1 : 0
 
   ami                  = var.ami_id
   instance_type        = var.instance_type
@@ -93,7 +93,7 @@ resource "aws_spot_instance_request" "atlantis" {
 
 resource "aws_ec2_tag" "spot_instance_tags" {
   region = var.region
-  count = var.spot_instance ? length(local.instance_tags) : 0
+  count  = var.spot_instance ? length(local.instance_tags) : 0
 
   resource_id = aws_spot_instance_request.atlantis[0].spot_instance_id
   key         = keys(local.instance_tags)[count.index]

--- a/server.tf
+++ b/server.tf
@@ -33,6 +33,7 @@ locals {
 }
 
 resource "aws_instance" "atlantis" {
+  region = var.region
   count = var.spot_instance ? 0 : 1
 
   ami                  = var.ami_id
@@ -59,6 +60,7 @@ resource "aws_instance" "atlantis" {
 }
 
 resource "aws_spot_instance_request" "atlantis" {
+  region = var.region
   count = var.spot_instance ? 1 : 0
 
   ami                  = var.ami_id
@@ -90,6 +92,7 @@ resource "aws_spot_instance_request" "atlantis" {
 }
 
 resource "aws_ec2_tag" "spot_instance_tags" {
+  region = var.region
   count = var.spot_instance ? length(local.instance_tags) : 0
 
   resource_id = aws_spot_instance_request.atlantis[0].spot_instance_id

--- a/variables.tf
+++ b/variables.tf
@@ -146,3 +146,8 @@ variable "azure_auth" {
   })
   default = null
 }
+
+variable "region" {
+  description = "AWS region to deploy the Atlantis server"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -150,4 +150,5 @@ variable "azure_auth" {
 variable "region" {
   description = "AWS region to deploy the Atlantis server"
   type        = string
+  default     = null
 }


### PR DESCRIPTION
With the latest AWS Provider release for Terraform, a new feature called Enhanced Region Support is now available. This allows users to deploy resources across multiple regions by specifying the region argument directly within resource and data blocks, rather than maintaining separate provider configurations for each region.

This allows our configuration to be made simpler as we can rely on a single provider setup instead of having to configure multiple providers with one in each region as we have done previously.

The goal of this PR is to upgrade the Terraform version used in this module and enable users to pass a region argument, which will automatically cascade through the module’s resources.
